### PR TITLE
登録画面でcontestが見つかれば、すぐに次の画面に遷移させる

### DIFF
--- a/public/coffee/views/wdquiz.question.registerView.coffee
+++ b/public/coffee/views/wdquiz.question.registerView.coffee
@@ -1,30 +1,27 @@
 ###
 最初の画面。
-開催中のコンテストがあれば、ボタン押下により次の画面に遷移する。
+開催中のコンテストがあれば、すぐに次の画面に遷移する。
 開催中のコンテストが無ければコンテストを作成し、ボタン押下により待機画面に遷移する。
 コンテストが作成されればユーザーの登録が受け付けられ、登録済みのユーザー名が表示される。
 ###
 
 wdquiz.question.registerView = Backbone.Marionette.ItemView.extend
   template: JST["wdquiz.question.register.jst"]
-  _enableKeyPress: false
   _onSuccessGetNotFinished: (result) ->
     if(result._id)
       console.log 'find contest'
       wdquiz.question.contest = result
-      @_enableKeyPress = true
+      wdquiz.question.goto.wait()
     else
       wdquiz.contestClient.create(
         (result) =>
           console.log 'create contest'
           wdquiz.question.contest = result
-          @_enableKeyPress = true
+          @pressKey = (keyCode) ->
+            wdquiz.question.goto.wait()
         () ->
           console.log 'error: contestClient.create'
       )
-  pressKey: (keyCode) ->
-    if(@_enableKeyPress)
-      wdquiz.question.goto.wait()
   onShow: ->
     wdquiz.contestClient.getNotFinished(
       _.bind @_onSuccessGetNotFinished, @


### PR DESCRIPTION
いちいち登録画面の入力待ちになっていると面倒なので
